### PR TITLE
Add command menu in mobile

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -33,56 +33,56 @@ export default function Page() {
                 target="_blank"
                 rel="noreferrer"
               >
-                <GlobeIcon className="h-3 w-3" />
+                <GlobeIcon className="size-3" />
                 {RESUME_DATA.location}
               </a>
             </p>
             <div className="flex gap-x-1 pt-1 font-mono text-sm text-muted-foreground print:hidden">
               {RESUME_DATA.contact.email ? (
                 <Button
-                  className="h-8 w-8"
+                  className="size-8"
                   variant="outline"
                   size="icon"
                   asChild
                 >
                   <a href={`mailto:${RESUME_DATA.contact.email}`}>
-                    <MailIcon className="h-4 w-4" />
+                    <MailIcon className="size-4" />
                   </a>
                 </Button>
               ) : null}
               {RESUME_DATA.contact.tel ? (
                 <Button
-                  className="h-8 w-8"
+                  className="size-8"
                   variant="outline"
                   size="icon"
                   asChild
                 >
                   <a href={`tel:${RESUME_DATA.contact.tel}`}>
-                    <PhoneIcon className="h-4 w-4" />
+                    <PhoneIcon className="size-4" />
                   </a>
                 </Button>
               ) : null}
               {RESUME_DATA.contact.social.map(social => (
                 <Button
                   key={social.name}
-                  className="h-8 w-8"
+                  className="size-8"
                   variant="outline"
                   size="icon"
                   asChild
                 >
                   <a href={social.url} target="_blank" rel="noreferrer">
-                    <social.icon className="h-4 w-4" />
+                    <social.icon className="size-4" />
                   </a>
                 </Button>
               ))}
-              <Button className="h-8 w-8" variant="outline" size="icon" asChild>
+              <Button className="size-8" variant="outline" size="icon" asChild>
                 <a
                   href="/cv.pdf"
                   target="_blank"
                   rel="noreferrer"
                   download="jatin-kumar.pdf"
                 >
-                  <DownloadIcon className="h-4 w-4" />
+                  <DownloadIcon className="size-4" />
                 </a>
               </Button>
             </div>

--- a/src/components/command-menu.tsx
+++ b/src/components/command-menu.tsx
@@ -11,6 +11,8 @@ import {
   CommandList,
   CommandSeparator,
 } from '@/components/ui/command';
+import { Button } from './ui/button';
+import { CommandIcon } from 'lucide-react';
 
 interface Props {
   links: { url: string; title: string }[];
@@ -33,13 +35,21 @@ export const CommandMenu = ({ links }: Props) => {
 
   return (
     <>
-      <p className="fixed bottom-0 left-0 right-0 border-t border-t-muted bg-white p-1 text-center text-sm text-muted-foreground print:hidden">
+      <p className="fixed bottom-0 left-0 right-0 hidden border-t border-t-muted bg-white p-1 text-center text-sm text-muted-foreground print:hidden xl:block">
         Press{' '}
         <kbd className="pointer-events-none inline-flex h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground opacity-100">
           <span className="text-xs">⌘</span>J
         </kbd>{' '}
         to open the command menu
       </p>
+      <Button
+        onClick={() => setOpen(open => !open)}
+        variant={'outline'}
+        size={'icon'}
+        className="fixed bottom-4 right-4 flex rounded-full shadow-2xl print:hidden xl:hidden"
+      >
+        <CommandIcon className="size-6" />
+      </Button>
       <CommandDialog open={open} onOpenChange={setOpen}>
         <CommandInput placeholder="Type a command or search..." />
         <CommandList>

--- a/src/components/project-card.tsx
+++ b/src/components/project-card.tsx
@@ -24,7 +24,7 @@ export function ProjectCard({ title, description, techStack, link }: Props) {
                 className="inline-flex items-center gap-1 hover:underline"
                 rel="noreferrer"
               >
-                {title} <span className="h-1 w-1 rounded-full bg-green-500" />
+                {title} <span className="size-1 rounded-full bg-green-500" />
               </a>
             ) : (
               title

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -42,7 +42,7 @@ const CommandInput = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
 >(({ className, ...props }, ref) => (
   <div className="flex items-center border-b px-3" cmdk-input-wrapper="">
-    <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+    <Search className="mr-2 size-4 shrink-0 opacity-50" />
     <CommandPrimitive.Input
       ref={ref}
       className={cn(

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -45,7 +45,7 @@ const DialogContent = React.forwardRef<
     >
       {children}
       <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-        <X className="h-4 w-4" />
+        <X className="size-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>


### PR DESCRIPTION
This pull request includes two commits:

- chore: use new `size-` property

- feat: add command menu in mobile

The changes in this pull request update the code to use the new `size-` property for icons and add a command menu for mobile devices.